### PR TITLE
Fixed Spinner Color (Dolphin)

### DIFF
--- a/Kuroi (Dark) by Ani.qss
+++ b/Kuroi (Dark) by Ani.qss
@@ -35,7 +35,7 @@ Red
 
 /* Every widget */
 QWidget {
-	background-color: #333333;
+	background-color: #323232;
 	color: #e6e6e6;
 	alternate-background-color: #3d3d3d;
 }

--- a/Kuroi (Dark) by Ani.qss
+++ b/Kuroi (Dark) by Ani.qss
@@ -35,7 +35,7 @@ Red
 
 /* Every widget */
 QWidget {
-	background-color: transparent;
+	background-color: #333333;
 	color: #e6e6e6;
 	alternate-background-color: #3d3d3d;
 }


### PR DESCRIPTION
Changed background-color for spinners, spinners previously appear white by default in some dialogs. This could be corrected to the theme's colors by hovering-over with the cursor, but would revert if the dialog was closed then re-opened.
Fix found by BParks21.